### PR TITLE
Version 1.0.1

### DIFF
--- a/cursorial.class.php
+++ b/cursorial.class.php
@@ -81,7 +81,10 @@ class Cursorial {
 
 		wp_enqueue_style(
 			'cursorial-admin',
-			CURSORIAL_PLUGIN_URL . 'css/admin.css'
+			CURSORIAL_PLUGIN_URL . 'css/admin.css',
+			array(
+				'thickbox'
+			)
 		);
 	}
 

--- a/cursorial.class.php
+++ b/cursorial.class.php
@@ -157,7 +157,6 @@ class Cursorial {
 	 *	'label' => __( 'Stuff you must read' ),
 	 *	'max' => 4, // Maximum amount of posts
 	 *	'related' => array( // Related content, child-post support
-	 *		'post_types' => array( 'post' ), // Version 2
 	 *		'max' => 2,
 	 *		'fields' => array( // Fields added here is shown in admin and can set to be overridable
 	 *											 // and/or optional/required to be added into the block

--- a/cursorial.php
+++ b/cursorial.php
@@ -4,7 +4,7 @@
 Plugin Name: Cursorial
 Plugin URI: https://github.com/klandestino/cursorial
 Description: Create custom loops with an easy drag-and-drop interface.
-Version: 1.0
+Version: 1.0.1
 Author: Klandestino
 Author URI: http://klandestino.se
 License: GPLv2

--- a/cursorial_block.class.php
+++ b/cursorial_block.class.php
@@ -99,9 +99,14 @@ class Cursorial_Block {
 		$time = current_time( 'timestamp' );
 		$count = 0;
 
-		foreach( $posts as $ref_id => $post_data ) {
-			$post = get_post( $ref_id );
-			setup_postdata( &$post );
+		foreach( $posts as $post_data ) {
+			$post = null;
+
+			if ( array_key_exists( 'id', $post_data ) ) {
+				$ref_id = $post_data[ 'id' ];
+				$post = get_post( $ref_id );
+				setup_postdata( &$post );
+			}
 
 			if ( ! empty( $post ) ) {
 				$fields = array(

--- a/cursorial_query.class.php
+++ b/cursorial_query.class.php
@@ -158,10 +158,11 @@ class Cursorial_Query {
 		) as $field => $args ) {
 			if ( is_string( $args ) ) {
 				add_filter( 'posts_where', array( &$this, $args ) );
-				$query = new WP_Query();
+				$query = new WP_Query( 'post_type=any' );
 				$posts = $query->get_posts();
 				remove_filter( 'posts_where', array( &$this, $args ) );
 			} else {
+				$args[ 'post_type' ] = 'any';
 				$query = new WP_Query( $args );
 				$posts = $query->get_posts();
 			}
@@ -170,7 +171,10 @@ class Cursorial_Query {
 				if ( count( $this->results ) >= $this->search_numberposts ) {
 					break;
 				}
-				$this->populate_results( $post );
+
+				if ( $post->post_type != Cursorial::POST_TYPE ) {
+					$this->populate_results( $post );
+				}
 			}
 		}
 	}

--- a/cursorial_query.class.php
+++ b/cursorial_query.class.php
@@ -33,7 +33,8 @@ class Cursorial_Query {
 					'field' => 'slug',
 					'terms' => array( $block_name )
 				)
-			)
+			),
+			'orderby' => 'date'
 		);
 	}
 
@@ -45,29 +46,33 @@ class Cursorial_Query {
 	 * @return void
 	 */
 	private function populate_results( $post ) {
-		if ( ! array_key_exists( $post->ID, $this->results ) ) {
-			setup_postdata( &$post );
-			$post_id = property_exists( $post, 'cursorial_ID' ) ? $post->cursorial_ID : $post->ID;
-			$post->post_title = apply_filters( 'the_title', $post->post_title );
-			$post->post_author = get_the_author();
-			$post->post_date = apply_filters( 'the_date', $post->post_date );
-			$post->post_excerpt = apply_filters( 'the_excerpt', $post->post_excerpt );
-			$post->post_content = apply_filters( 'the_content', $post->post_content );
-			$post->image = apply_filters( 'cursorial_image_id', get_post_thumbnail_id( $post_id ) );
-			$post->cursorial_image = wp_get_attachment_image_src( $post->image );
-			$post->cursorial_depth = apply_filters( 'cursorial_depth', ( int ) get_post_meta( $post_id, 'cursorial-post-depth', true ) );
-
-			$hidden_fields = get_post_meta( $post_id, 'cursorial-post-hidden-fields', true );
-
-			if ( is_array( $hidden_fields ) ) {
-				foreach( $hidden_fields as $field_name ) {
-					$hidden_field_name = $field_name . '_hidden';
-					$post->$hidden_field_name = true;
-				}
+		foreach( $this->results as $result ) {
+			if ( $result->ID === $post->ID ) {
+				return;
 			}
-
-			$this->results[ $post->ID ] = $post;
 		}
+
+		setup_postdata( &$post );
+		$post_id = property_exists( $post, 'cursorial_ID' ) ? $post->cursorial_ID : $post->ID;
+		$post->post_title = apply_filters( 'the_title', $post->post_title );
+		$post->post_author = get_the_author();
+		$post->post_date = apply_filters( 'the_date', $post->post_date );
+		$post->post_excerpt = apply_filters( 'the_excerpt', $post->post_excerpt );
+		$post->post_content = apply_filters( 'the_content', $post->post_content );
+		$post->image = apply_filters( 'cursorial_image_id', get_post_thumbnail_id( $post_id ) );
+		$post->cursorial_image = wp_get_attachment_image_src( $post->image );
+		$post->cursorial_depth = apply_filters( 'cursorial_depth', ( int ) get_post_meta( $post_id, 'cursorial-post-depth', true ) );
+
+		$hidden_fields = get_post_meta( $post_id, 'cursorial-post-hidden-fields', true );
+
+		if ( is_array( $hidden_fields ) ) {
+			foreach( $hidden_fields as $field_name ) {
+				$hidden_field_name = $field_name . '_hidden';
+				$post->$hidden_field_name = true;
+			}
+		}
+
+		$this->results[] = $post;
 	}
 
 	/**

--- a/js/jquery.cursorial.js
+++ b/js/jquery.cursorial.js
@@ -310,7 +310,6 @@
 											field = $(
 												'<input class="cursorial-field cursorial-field-' + i + '" type="hidden" value="' + imageId + '"/>' +
 												'<a class="cursorial-field cursorial-image-link thickbox" href="media-upload.php?post_id=' + postId + '&amp;type=image&amp;TB_iframe=1width=640&height=546" title="' + cursorial_i18n( 'Set featured image' ) + '">' + cursorial_i18n( 'Set featured image' ) + '</a>'
-//http://cursorial.spurge.hacks.ath.cx/wp-admin/media-upload.php?post_id=2&type=image&TB_iframe=1&width=640&height=546
 											);
 										} else {
 											field = $( '<p class="cursorial-field description">' + cursorial_i18n( 'You need to save this block before you can change image.' ) + '</p>' );
@@ -676,7 +675,7 @@
 		function save() {
 			var data = {
 				action: 'save-block',
-				posts: {},
+				posts: [],
 				block: $( this ).data( 'cursorial-block-name' )
 			};
 
@@ -689,7 +688,7 @@
 				// therefore we've stored the post id in a class name :(
 				var id = $( posts[ i ] ).attr( 'id' ).match( /cursorial-post-([0-9]+)/ );
 				if ( id ) {
-					data.posts[ id[ 1 ] ] = {
+					var post = {
 						id: id[ 1 ],
 						depth: $( posts[ i ] ).data( 'cursorial-child-status' ) === true ? 1 : 0
 					};
@@ -699,14 +698,16 @@
 					for( var ii in settings ) {
 						if ( typeof( fields[ ii ] ) != 'undefined' ) {
 							if ( settings[ ii ].overridable ) {
-								data.posts[ id[ 1 ] ][ ii ] = fields[ ii ];
+								post[ ii ] = fields[ ii ];
 							}
 
 							if ( settings[ ii ].optional && typeof( fields[ ii + '_hidden' ] ) != 'undefined' ) {
-								data.posts[ id[ 1 ] ][ ii + '_hidden' ] = true;
+								post[ ii + '_hidden' ] = true;
 							}
 						}
 					}
+
+					data.posts.push( post );
 				}
 			}
 

--- a/js/jquery.cursorial.js
+++ b/js/jquery.cursorial.js
@@ -304,16 +304,17 @@
 										field.height( element.height() > 100 ? element.height() : 100 );
 										break;
 									case 'image' :
-										var postId = $( this ).data( 'cursorial-post-data' ).cursorial_ID;
-										if ( postId ) {
-											var imageId = $( this ).data( 'cursorial-post-data' ).image;
-											field = $(
-												'<input class="cursorial-field cursorial-field-' + i + '" type="hidden" value="' + imageId + '"/>' +
-												'<a class="cursorial-field cursorial-image-link thickbox" href="media-upload.php?post_id=' + postId + '&amp;type=image&amp;TB_iframe=1width=640&height=546" title="' + cursorial_i18n( 'Set featured image' ) + '">' + cursorial_i18n( 'Set featured image' ) + '</a>'
-											);
-										} else {
-											field = $( '<p class="cursorial-field description">' + cursorial_i18n( 'You need to save this block before you can change image.' ) + '</p>' );
+										var postId = 0;
+
+										if ( typeof( data[ 'cursorial_ID' ] ) != 'undefined' ) {
+											postId = data.cursorial_ID;
 										}
+
+										var imageId = $( this ).data( 'cursorial-post-data' ).image;
+										field = $(
+											'<input class="cursorial-field cursorial-field-' + i + '" type="hidden" value="' + imageId + '"/>' +
+											'<a class="cursorial-field cursorial-image-link thickbox" href="media-upload.php?post_id=' + postId + '&amp;type=image&amp;TB_iframe=1&amp;width=640&height=546" title="' + cursorial_i18n( 'Set featured image' ) + '">' + cursorial_i18n( 'Set featured image' ) + '</a>'
+										);
 										break;
 									default :
 										field = $( '<input class="cursorial-field cursorial-field-' + i + ' widefat" type="text"/>' );
@@ -1389,12 +1390,11 @@ if ( typeof( WPSetThumbnailID ) == 'undefined' ) {
 	 * This callback sets the post image field value to the chosen id.
 	 * @function
 	 * @name WPSetThumbnailID
-	 * @param {int|string} c The attachment id
-	 * @param {?} b I don't know
+	 * @param {int|string} id The attachment id
 	 * @return {void}
 	 */
-	WPSetThumbnailID = function( c, b ) {
-		jQuery( '.cursorial-post-edit .cursorial-field-image' ).val( c );
+	var WPSetThumbnailID = function( id ) {
+		jQuery( '.cursorial-post-edit .cursorial-field-image' ).val( id );
 	}
 }
 
@@ -1407,8 +1407,13 @@ if ( typeof( WPSetThumbnailHTML ) == 'undefined' ) {
 	 * @param {object} e The DOM-element where the image is places
 	 * @return {void}
 	 */
-	WPSetThumbnailHTML = function( e ) {
-		var image = jQuery( e ).find( 'img' );
+	var WPSetThumbnailHTML = function( e ) {
+		var image = jQuery( e );
+
+		if ( ! image.is( 'img' ) ) {
+			image = image.find( 'img' );
+		}
+
 		if ( image.length > 0 ) {
 			jQuery( 'a.cursorial-image-link-current' ).parents( '.cursorial-post-edit' ).each( function() {;
 				var data = jQuery( this ).data( 'cursorial-post-data' );
@@ -1419,5 +1424,34 @@ if ( typeof( WPSetThumbnailHTML ) == 'undefined' ) {
 				jQuery( this ).find( 'a.cursorial-image-link-current' ).removeClass( 'cursorial-image-link-current' );
 			} );
 		}
+	}
+}
+
+if ( typeof( send_to_editor ) == 'undefined' ) {
+	/**
+	 * Image-picker-popup calls this function when you hit the "Insert
+	 * into Post" button.
+	 * @function
+	 * @name send_to_editor
+	 * @param {string} e HTML element containing the image
+	 * @returns {void}
+	 */
+	var send_to_editor = function( e ) {
+		var image = jQuery( e );
+
+		if ( ! image.is( 'img' ) ) {
+			image = image.find( 'img' );
+		}
+
+		if ( image.length > 0 ) {
+			var id = image.attr( 'class' ).match( /wp-image-([0-9]+)/i );
+			if ( id ) {
+				image.width( 150 );
+				image.height( 150 );
+				WPSetThumbnailHTML( image );
+				WPSetThumbnailID( id[ 1 ] );
+			}
+		}
+		jQuery( '#TB_closeWindowButton' ).trigger( 'click' );
 	}
 }

--- a/js/jquery.cursorial.js
+++ b/js/jquery.cursorial.js
@@ -309,7 +309,8 @@
 											var imageId = $( this ).data( 'cursorial-post-data' ).image;
 											field = $(
 												'<input class="cursorial-field cursorial-field-' + i + '" type="hidden" value="' + imageId + '"/>' +
-												'<a class="cursorial-field cursorial-image-link thickbox" href="media-upload.php?post_id=' + postId + '&amp;type=image&amp;TB_iframe=1" title="' + cursorial_i18n( 'Set featured image' ) + '">' + cursorial_i18n( 'Set featured image' ) + '</a>'
+												'<a class="cursorial-field cursorial-image-link thickbox" href="media-upload.php?post_id=' + postId + '&amp;type=image&amp;TB_iframe=1width=640&height=546" title="' + cursorial_i18n( 'Set featured image' ) + '">' + cursorial_i18n( 'Set featured image' ) + '</a>'
+//http://cursorial.spurge.hacks.ath.cx/wp-admin/media-upload.php?post_id=2&type=image&TB_iframe=1&width=640&height=546
 											);
 										} else {
 											field = $( '<p class="cursorial-field description">' + cursorial_i18n( 'You need to save this block before you can change image.' ) + '</p>' );
@@ -1252,6 +1253,12 @@
 			$( this ).data( 'cursorial-hide-long-content-link', link );
 		}
 
+		/**
+		 * Removes show/hide links
+		 * @function
+		 * @name removeLink
+		 * @returns {void}
+		 */
 		function removeLink() {
 			$( this ).nextUntil( ':not(a.cursorial-hide-long-content-link)' ).remove();
 			$( this ).parent( '.cursorial-hide-long-content-wrapper' ).nextUntil( ':not(a.cursorial-hide-long-content-link)' ).remove();

--- a/readme.md
+++ b/readme.md
@@ -114,7 +114,6 @@ Here's some lines of code:
 							)
 						)
 					)
-					)
 				),
 				array( // Second argument is an array with some admin config
 					__( 'Home' ) => array( // The key is the name of the page where editors can edit specified loops
@@ -252,6 +251,18 @@ Screenshots
 
 Changelog
 ---------
+
+### v1.0.1
+
+#### Bugfixes
+
+* Fixed issue with hidden image selector.
+* Posts' order failed in chrome and maybe some other browsers.
+
+#### New features
+
+* Search queries looks for all post types except cursorials. Thereby you
+	can add pages and custom post types to your cursorial loops.
 
 ### v1.0
 

--- a/readme.md
+++ b/readme.md
@@ -258,6 +258,8 @@ Changelog
 
 * Fixed issue with hidden image selector.
 * Posts' order failed in chrome and maybe some other browsers.
+* Fixed issue with using the "Insert into Post"-button in image
+	selector.
 
 #### New features
 

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Cursorial
 * Tags: cursorial, content, post, custom, editing, loops
 * Requires at least: 3.2.1
 * Tested up to: 3.3.1
-* Stable tag: 1.0
+* Stable tag: 1.0.1
 * License: GPLv2
 
 Create custom loops with an easy drag-and-drop interface.

--- a/readme.md
+++ b/readme.md
@@ -253,37 +253,6 @@ Screenshots
 Changelog
 ---------
 
-### v0.9
-
-First stable beta release with some of the main features.
-
-* Register blocks with custom loops and gather them in the administration.
-* Search posts in the administration and drag posts into cursorial
-	blocks.
-* Drag posts between blocks.
-* Override posts' contents.
-* Images will be set by wordpress' own image library.
-* Posts can be set to have childs.
-* Admin pages templates are overridable.
-* Loops for displaying block posts are available through both a query
-	method and a template fetcher.
-
-### v0.9.1
-
-* Maximum number of posts can be set for both blocks and post childs.
-
-### v0.9.2
-
-* An optional show/hide option on fields.
-
-### v0.9.3
-
-* Administration interface have a saved/unsaved status indicator.
-* There's a save all blocks button.
-* The jQuery block plugin have some of it's internal functions available
-	from outside.
-* Swedish translation.
-
 ### v1.0
 
 #### Bugfixes
@@ -304,6 +273,37 @@ First stable beta release with some of the main features.
 	get_cursorial_block() and query_cursorial_posts().
 * Search result is limited.
 
+### v0.9.3
+
+* Administration interface have a saved/unsaved status indicator.
+* There's a save all blocks button.
+* The jQuery block plugin have some of it's internal functions available
+	from outside.
+* Swedish translation.
+
+### v0.9.2
+
+* An optional show/hide option on fields.
+
+### v0.9.1
+
+* Maximum number of posts can be set for both blocks and post childs.
+
+### v0.9
+
+First stable beta release with some of the main features.
+
+* Register blocks with custom loops and gather them in the administration.
+* Search posts in the administration and drag posts into cursorial
+	blocks.
+* Drag posts between blocks.
+* Override posts' contents.
+* Images will be set by wordpress' own image library.
+* Posts can be set to have childs.
+* Admin pages templates are overridable.
+* Loops for displaying block posts are available through both a query
+	method and a template fetcher.
+
 Upcoming
 --------
 
@@ -314,3 +314,4 @@ Upcoming
 ### v1.1
 
 * An included widget that shows chosen block.
+* Support for different post types.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 * Tags: cursorial, content, post, custom, editing, loops
 * Requires at least: 3.2.1
 * Tested up to: 3.3.1
-* Stable tag: 1.0
+* Stable tag: 1.0.1
 * License: GPLv2
 
 Create custom loops with an easy drag-and-drop interface.

--- a/readme.txt
+++ b/readme.txt
@@ -252,6 +252,8 @@ directory to see how the jQuery plugins are applied.
 
 * Fixed issue with hidden image selector.
 * Posts' order failed in chrome and maybe some other browsers.
+* Fixed issue with using the "Insert into Post"-button in image
+	selector.
 
 **New features**
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,6 @@ Here's some lines of code:
 							)
 						)
 					)
-					)
 				),
 				array( // Second argument is an array with some admin config
 					__( 'Home' ) => array( // The key is the name of the page where editors can edit specified loops
@@ -246,6 +245,18 @@ directory to see how the jQuery plugins are applied.
 1. An overview of the administration.
 
 == Changelog ==
+
+= v1.0.1 =
+
+**Bugfixes**
+
+* Fixed issue with hidden image selector.
+* Posts' order failed in chrome and maybe some other browsers.
+
+**New features**
+
+* Search queries looks for all post types except cursorials. Thereby you
+	can add pages and custom post types to your cursorial loops.
 
 = v1.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -247,37 +247,6 @@ directory to see how the jQuery plugins are applied.
 
 == Changelog ==
 
-= v0.9 =
-
-First stable beta release with some of the main features.
-
-* Register blocks with custom loops and gather them in the administration.
-* Search posts in the administration and drag posts into cursorial
-	blocks.
-* Drag posts between blocks.
-* Override posts' contents.
-* Images will be set by wordpress' own image library.
-* Posts can be set to have childs.
-* Admin pages templates are overridable.
-* Loops for displaying block posts are available through both a query
-	method and a template fetcher.
-
-= v0.9.1 =
-
-* Maximum number of posts can be set for both blocks and post childs.
-
-= v0.9.2 =
-
-* An optional show/hide option on fields.
-
-= v0.9.3 =
-
-* Administration interface have a saved/unsaved status indicator.
-* There's a save all blocks button.
-* The jQuery block plugin have some of it's internal functions available
-	from outside.
-* Swedish translation.
-
 = v1.0 =
 
 **Bugfixes**
@@ -298,6 +267,37 @@ First stable beta release with some of the main features.
 	get_cursorial_block() and query_cursorial_posts().
 * Search result is limited.
 
+= v0.9.3 =
+
+* Administration interface have a saved/unsaved status indicator.
+* There's a save all blocks button.
+* The jQuery block plugin have some of it's internal functions available
+	from outside.
+* Swedish translation.
+
+= v0.9.2 =
+
+* An optional show/hide option on fields.
+
+= v0.9.1 =
+
+* Maximum number of posts can be set for both blocks and post childs.
+
+= v0.9 =
+
+First stable beta release with some of the main features.
+
+* Register blocks with custom loops and gather them in the administration.
+* Search posts in the administration and drag posts into cursorial
+	blocks.
+* Drag posts between blocks.
+* Override posts' contents.
+* Images will be set by wordpress' own image library.
+* Posts can be set to have childs.
+* Admin pages templates are overridable.
+* Loops for displaying block posts are available through both a query
+	method and a template fetcher.
+
 == Upcoming ==
 
 = Bugfixes =
@@ -307,3 +307,4 @@ First stable beta release with some of the main features.
 = v1.1 =
 
 * An included widget that shows chosen block.
+* Support for different post types.


### PR DESCRIPTION
Bugs
- Fixed issue with hidden image selector.
- Posts' order failed in chrome and maybe some other browsers.
- Fixed issue with using the "Insert into Post"-button in image selector.

Also

Search queries looks for all post types except cursorials. Thereby you can add pages and custom post types to your cursorial loops.
